### PR TITLE
feat: support DateTime64Column precision

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -60,9 +60,9 @@ final readonly class Column
         return new Internal\DateTimeColumn($value);
     }
 
-    public static function dateTime64(\DateTimeInterface $value): ColumnValuer
+    public static function dateTime64(\DateTimeInterface $value, int $precision = 3): ColumnValuer
     {
-        return new Internal\DateTime64Column($value);
+        return new Internal\DateTime64Column($value, $precision);
     }
 
     public static function uint8(int $value): ColumnValuer

--- a/src/Internal/DateTime64Column.php
+++ b/src/Internal/DateTime64Column.php
@@ -35,9 +35,23 @@ use Kafkiansky\PHPClick\ColumnValuer;
  */
 final readonly class DateTime64Column implements ColumnValuer
 {
+    /** @var list<int> */
+    private const POW10 = [
+        1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000
+    ];
+
+    /**
+     * @param \DateTimeInterface $value
+     * @param int $precision DateTime64(N) where N is precision, 0–9 | 3 by default
+     * @throws \InvalidArgumentException
+     */
     public function __construct(
         private \DateTimeInterface $value,
+        private int $precision = 3,
     ) {
+        if ($this->precision < 0 || $this->precision > 9) {
+            throw new \InvalidArgumentException('DateTime64 precision must be 0–9.');
+        }
     }
 
     public function write(Buffer $buffer): void
@@ -45,6 +59,18 @@ final readonly class DateTime64Column implements ColumnValuer
         $seconds = $this->value->getTimestamp();
         $microseconds = (int) $this->value->format('u');
 
-        $buffer->writeInt64(($seconds * 1_000_000) + $microseconds);
+        $base = $seconds * self::POW10[$this->precision];
+
+        if ($this->precision === 0) {
+            $fraction = 0; // truncate fractional part entirely
+        } elseif ($this->precision <= 6) {
+            // downscale microseconds to 10^-N with integer truncation
+            $fraction = intdiv($microseconds, self::POW10[6 - $this->precision]);
+        } else {
+            // upscale microseconds to 10^-N
+            $fraction = $microseconds * self::POW10[$this->precision - 6];
+        }
+
+        $buffer->writeInt64($base + $fraction);
     }
 }

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -171,6 +171,7 @@ final class ColumnTest extends TestCase
         yield 'datetime64' => [
             Column::dateTime64(
                 (new \DateTimeImmutable())->setTimestamp(1719758949),
+                6,
             ),
             static function (Buffer $buffer): \DateTimeImmutable {
                 $timestamp = $buffer->consumeInt64();


### PR DESCRIPTION
`DateTime64Column` originally assumed the target column was always `DateTime64(6)`, but in ClickHouse the precision is configurable in the range `[0 : 9]`. This PR adds a `precision` argument (default `3`) so the class can correctly encode values for any `DateTime64(N)`. For precisions `< 6` the fractional part is truncated, for `= 6` microseconds are used directly, and for `> 6` microseconds are scaled up. All arithmetic stays in integers to avoid float issues. This makes the column work properly with `DateTime64(3)`, `DateTime64(9)`, and everything in between.