### PR TITLE
Support kafkiansky/binary ^0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "kafkiansky/binary": "^0.4.0",
+        "kafkiansky/binary": "^0.4.0 || ^0.5.0",
         "amphp/http-client": "^5.1"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
Updated the `kafkiansky/binary` dependency constraint to support both the current ^0.4.0 and the new ^0.5.0 versions.

## Changes
- Modified `composer.json` to allow `kafkiansky/binary` versions ^0.4.0 or ^0.5.0

## Details
This change increases compatibility by permitting the use of the newer 0.5.0 release of the `kafkiansky/binary` library while maintaining backward compatibility with existing 0.4.0 installations. This enables users to upgrade to the latest version of the dependency when they're ready.

https://claude.ai/code/session_017n9wdStvFE4YMax6NtbTDz